### PR TITLE
Fix MonadIO, add instance for Eff

### DIFF
--- a/src/Control/Monad/IO/Class.purs
+++ b/src/Control/Monad/IO/Class.purs
@@ -1,16 +1,20 @@
 module Control.Monad.IO.Class where
-  import Control.Category (id)
-  import Control.Monad (class Monad)
+  import Prelude
   import Control.Monad.Aff (Aff)
+  import Control.Monad.Eff (Eff)
+  import Control.Monad.Eff.Class (liftEff)
   import Control.Monad.IO (IO)
 
   import Unsafe.Coerce (unsafeCoerce)
 
   class Monad m <= MonadIO m where
-    liftIO :: forall a. IO a -> m a
+    liftIO :: forall a. m a -> IO a
 
   instance monadIOIO :: MonadIO IO where
     liftIO = id
 
   instance monadIOAff :: MonadIO (Aff e) where
     liftIO = unsafeCoerce
+
+  instance monadIOEff :: MonadIO (Eff e) where
+    liftIO = liftIO <<< (liftEff :: Eff e ~> Aff e)


### PR DESCRIPTION
The current MonadIO coerces from IO to whatever `m`, I assume the intention was actually to lift values from some `m` into `IO`?
