### PR TITLE
psc 0.10 support and IOSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,14 @@ Therefore, MTL and direct-Free approaches can be considered alternatives to Pure
 `IO` is a newtype for `Aff`, which you can unwrap to be used in your `main`:
 
 ```haskell
-import Data.Newtype (unwrap)
-
-unwrap :: forall a. IO a -> Aff (infinity :: INFINITY) a
+runIO :: forall a. IO a -> Aff (infinity :: INFINITY) a
 ```
 
 This converts an `IO` into an `Aff`, which you can then "convert" into a
 runnable `Eff` using `launchAff` or `runAff`.
 
 The effect row is closed, which is intentional because `INFINITY` represents
-all possible effects. This will help ensure you only call `unwrap` at the top
+all possible effects. This will help ensure you only call `runIO` at the top
 level of your program.
 
 Besides this, `IO` has almost all the same instances as `Aff`, and may be used

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Similarly, if we were using `Free` directly, instead of using type classes to ab
 ```haskell
 data ConfigF a
   = ReadConfig (Config -> a)
-  
+
 serverAddress :: ReaderT (PrismT' f ConfigF) (Free f) InetAddress
 ```
 
@@ -58,18 +58,20 @@ Therefore, MTL and direct-Free approaches can be considered alternatives to Pure
 `IO` only has one function, which should only be used in your `main`:
 
 ```haskell
-runIO :: forall a. IO a -> Aff (infinity :: INFINITY) a
+unwrap :: forall a. IO a -> Aff (infinity :: INFINITY) a
 ```
 
 This converts an `IO` into an `Aff`, which you can then "convert" into a
 runnable `Eff` using `launchAff` or `runAff`.
 
 The effect row is closed, which is intentional because `INFINITY` represents
-all possible effects. This will help ensure you only call `runIO` at the top
+all possible effects. This will help ensure you only call `unwrap` at the top
 level of your program.
 
 Besides this, `IO` has almost all the same instances as `Aff`, and may be used
 in the same way. In addition, a new `MonadIO` class has been introduced which
 allows you to lift `IO` computations into other monads that are as powerful.
+
+Similarly, `IOSync` exists as an alternative for `Eff`.
 
 Happy nuke launching!

--- a/README.md
+++ b/README.md
@@ -55,9 +55,11 @@ Therefore, MTL and direct-Free approaches can be considered alternatives to Pure
 
 # Usage
 
-`IO` only has one function, which should only be used in your `main`:
+`IO` is a newtype for `Aff`, which you can unwrap to be used in your `main`:
 
 ```haskell
+import Data.Newtype (unwrap)
+
 unwrap :: forall a. IO a -> Aff (infinity :: INFINITY) a
 ```
 

--- a/bower.json
+++ b/bower.json
@@ -7,9 +7,17 @@
     "output"
   ],
   "dependencies": {
-    "purescript-aff": "1.1.0"
+    "purescript-aff": "^2.0.3",
+    "purescript-control": "^2.0.0",
+    "purescript-eff": "^2.0.0",
+    "purescript-exceptions": "^2.0.0",
+    "purescript-monoid": "^2.2.0",
+    "purescript-newtype": "^1.3.0",
+    "purescript-prelude": "^2.5.0",
+    "purescript-tailrec": "^2.0.2",
+    "purescript-transformers": "^2.3.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "^1.0.0"
+    "purescript-psci-support": "^2.0.0"
   }
 }

--- a/src/Control/Monad/IO.purs
+++ b/src/Control/Monad/IO.purs
@@ -1,28 +1,31 @@
 module Control.Monad.IO
-  ( INFINITY
+  ( module Control.Monad.IO.Effect
   , IO(..)
+  , launchIO
   ) where
 
 import Control.Alt (class Alt)
 import Control.Alternative (class Alternative)
-import Control.Monad.Aff (Aff)
+import Control.Monad.Aff (Aff, launchAff)
 import Control.Monad.Aff.Class (class MonadAff)
 import Control.Monad.Aff.Unsafe (unsafeCoerceAff)
 import Control.Monad.Eff.Class (class MonadEff, liftEff)
 import Control.Monad.Eff.Exception (Error)
 import Control.Monad.Eff.Unsafe (unsafeCoerceEff)
 import Control.Monad.Error.Class (class MonadError)
-import Control.Monad.IO (INFINITY)
+import Control.Monad.IO.Effect (INFINITY)
+import Control.Monad.IOSync (IOSync)
 import Control.Monad.Rec.Class (class MonadRec)
 import Control.MonadZero (class MonadZero)
 import Control.Plus (class Plus)
 import Data.Monoid (class Monoid)
-import Data.Newtype (class Newtype, wrap)
+import Data.Newtype (class Newtype, unwrap, wrap)
 import Prelude
 
-foreign import data INFINITY :: Effect
-
 newtype IO a = IO (Aff (infinity :: INFINITY) a)
+
+launchIO :: ∀ a. IO a -> IOSync Unit
+launchIO = void <<< liftEff <<< launchAff <<< unwrap
 
 derive instance newtypeIO :: Newtype (IO a) _
 

--- a/src/Control/Monad/IO.purs
+++ b/src/Control/Monad/IO.purs
@@ -14,7 +14,6 @@ import Control.Monad.Eff.Unsafe (unsafeCoerceEff)
 import Control.Monad.Error.Class (class MonadError)
 import Control.Monad.IO (INFINITY)
 import Control.Monad.Rec.Class (class MonadRec)
-import Control.MonadPlus (class MonadPlus)
 import Control.MonadZero (class MonadZero)
 import Control.Plus (class Plus)
 import Data.Monoid (class Monoid)
@@ -54,5 +53,3 @@ derive newtype instance plusIO :: Plus IO
 derive newtype instance alternativeIO :: Alternative IO
 
 derive newtype instance monadZeroIO :: MonadZero IO
-
-derive newtype instance monadPlusIO :: MonadPlus IO

--- a/src/Control/Monad/IO.purs
+++ b/src/Control/Monad/IO.purs
@@ -1,6 +1,8 @@
 module Control.Monad.IO
   ( module Control.Monad.IO.Effect
   , IO(..)
+  , runIO
+  , runIO'
   , launchIO
   ) where
 
@@ -23,6 +25,12 @@ import Data.Newtype (class Newtype, unwrap, wrap)
 import Prelude
 
 newtype IO a = IO (Aff (infinity :: INFINITY) a)
+
+runIO :: IO ~> Aff (infinity :: INFINITY)
+runIO = unwrap
+
+runIO' :: ∀ eff. IO ~> Aff (infinity :: INFINITY | eff)
+runIO' = unsafeCoerceAff <<< unwrap
 
 launchIO :: ∀ a. IO a -> IOSync Unit
 launchIO = void <<< liftEff <<< launchAff <<< unwrap

--- a/src/Control/Monad/IO.purs
+++ b/src/Control/Monad/IO.purs
@@ -1,87 +1,58 @@
-module Control.Monad.IO (IO, INFINITY, AffIO(..), runIO) where
-  import Prelude
+module Control.Monad.IO
+  ( INFINITY
+  , IO(..)
+  ) where
 
-  import Control.Alt (class Alt, alt)
-  import Control.Alternative (class Alternative)
-  import Control.Monad.Eff (Eff)
-  import Control.Monad.Eff.Class (class MonadEff, liftEff)
-  import Control.Monad.Aff (Aff)
-  import Control.Monad.Aff.Class (class MonadAff)
-  import Control.Monad.Eff.Exception (Error)
-  import Control.Monad.Error.Class (class MonadError, throwError, catchError)
-  import Control.Monad.Rec.Class (class MonadRec, tailRecM)
-  import Control.MonadPlus (class MonadZero, class MonadPlus, empty)
-  import Control.Parallel.Class (class MonadRace, class MonadPar, par, race, stall)
-  import Control.Plus (class Plus)
+import Control.Alt (class Alt)
+import Control.Alternative (class Alternative)
+import Control.Monad.Aff (Aff)
+import Control.Monad.Aff.Class (class MonadAff)
+import Control.Monad.Aff.Unsafe (unsafeCoerceAff)
+import Control.Monad.Eff.Class (class MonadEff, liftEff)
+import Control.Monad.Eff.Exception (Error)
+import Control.Monad.Eff.Unsafe (unsafeCoerceEff)
+import Control.Monad.Error.Class (class MonadError)
+import Control.Monad.IO (INFINITY)
+import Control.Monad.Rec.Class (class MonadRec)
+import Control.MonadPlus (class MonadPlus)
+import Control.MonadZero (class MonadZero)
+import Control.Plus (class Plus)
+import Data.Monoid (class Monoid)
+import Data.Newtype (class Newtype, wrap)
+import Prelude
 
-  import Data.Monoid (class Monoid, mempty)
+foreign import data INFINITY :: Effect
 
-  import Unsafe.Coerce (unsafeCoerce)
+newtype IO a = IO (Aff (infinity :: INFINITY) a)
 
-  foreign import data IO :: * -> *
+derive instance newtypeIO :: Newtype (IO a) _
 
-  foreign import data INFINITY :: !
+derive newtype instance functorIO     :: Functor     IO
+derive newtype instance applyIO       :: Apply       IO
+derive newtype instance applicativeIO :: Applicative IO
+derive newtype instance bindIO        :: Bind        IO
+derive newtype instance monadIO       :: Monad       IO
 
-  type AffIO a = Aff (infinity :: INFINITY) a
+derive newtype instance monadRecIO :: MonadRec IO
 
-  runIO :: forall a. IO a -> AffIO a
-  runIO = unsafeCoerce
+derive newtype instance semigroupIO :: (Semigroup a) => Semigroup (IO a)
 
-  toIO :: forall e a. Aff e a -> IO a
-  toIO = unsafeCoerce
+derive newtype instance monoidIO :: (Monoid a) => Monoid (IO a)
 
-  instance semigroupIO :: (Semigroup a) => Semigroup (IO a) where
-    append a b = toIO (append (runIO a) (runIO b))
+instance monadAffIO :: MonadAff eff IO where
+  liftAff = wrap <<< unsafeCoerceAff
 
-  instance monoidIO :: (Monoid a) => Monoid (IO a) where
-    mempty = toIO (pure mempty)
+instance monadEffIO :: MonadEff eff IO where
+  liftEff = wrap <<< liftEff <<< unsafeCoerceEff
 
-  instance functorIO :: Functor IO where
-    map f fa = toIO (map f (runIO fa))
+derive newtype instance monadErrorIO :: MonadError Error IO
 
-  instance applyIO :: Apply IO where
-    apply ff fa = toIO (apply (runIO ff) (runIO fa))
+derive newtype instance altIO :: Alt IO
 
-  instance applicativeIO :: Applicative IO where
-    pure v = toIO (pure v)
+derive newtype instance plusIO :: Plus IO
 
-  instance bindIO :: Bind IO where
-    bind fa f = toIO (bind (runIO fa) (unsafeCoerce f))
+derive newtype instance alternativeIO :: Alternative IO
 
-  instance monadIO :: Monad IO
+derive newtype instance monadZeroIO :: MonadZero IO
 
-  instance monadEffIO :: MonadEff e IO where
-    liftEff = liftEff'
-      where
-        liftEff' :: forall a. Eff e a -> IO a
-        liftEff' eff = toIO (liftEff eff :: Aff e a)
-
-  instance monadAffIO :: MonadAff e IO where
-    liftAff = toIO
-
-  instance monadErrorIO :: MonadError Error IO where
-    throwError e = toIO (throwError e)
-
-    catchError io f = toIO (catchError (runIO io) (runIO <$> f))
-
-  instance altIO :: Alt IO where
-    alt a1 a2 = toIO (alt (runIO a1) (runIO a2))
-
-  instance plusIO :: Plus IO where
-    empty = toIO empty
-
-  instance alternativeIO :: Alternative IO
-
-  instance monadZero :: MonadZero IO
-
-  instance monadPlusIO :: MonadPlus IO
-
-  instance monadRecIO :: MonadRec IO where
-    tailRecM f a = toIO (tailRecM (unsafeCoerce f) a)
-
-  instance monadParIO :: MonadPar IO where
-    par f ma mb = toIO (par f (runIO ma) (runIO mb))
-
-  instance monadRaceIO :: MonadRace IO where
-    stall = toIO stall
-    race a1 a2 = toIO (race (runIO a1) (runIO a2))
+derive newtype instance monadPlusIO :: MonadPlus IO

--- a/src/Control/Monad/IO/Class.purs
+++ b/src/Control/Monad/IO/Class.purs
@@ -1,10 +1,10 @@
 module Control.Monad.IO.Class where
-  import Control.Category (id)
-  import Control.Monad (class Monad)
-  import Control.Monad.IO (IO)
 
-  class Monad m <= MonadIO m where
-    liftIO :: forall a. IO a -> m a
+import Control.Monad.IO (IO)
+import Prelude
 
-  instance monadIOIO :: MonadIO IO where
-    liftIO = id
+class (Monad m) <= MonadIO m where
+  liftIO :: ∀ a. IO a -> m a
+
+instance monadIOIO :: MonadIO IO where
+  liftIO = id

--- a/src/Control/Monad/IO/Class.purs
+++ b/src/Control/Monad/IO/Class.purs
@@ -4,7 +4,7 @@ import Control.Monad.IO (IO)
 import Prelude
 
 class (Monad m) <= MonadIO m where
-  liftIO :: ∀ a. IO a -> m a
+  liftIO :: IO ~> m
 
 instance monadIOIO :: MonadIO IO where
   liftIO = id

--- a/src/Control/Monad/IO/Effect.purs
+++ b/src/Control/Monad/IO/Effect.purs
@@ -1,0 +1,5 @@
+module Control.Monad.IO.Effect
+  ( INFINITY
+  ) where
+
+foreign import data INFINITY :: Effect

--- a/src/Control/Monad/IOSync.purs
+++ b/src/Control/Monad/IOSync.purs
@@ -1,6 +1,8 @@
 module Control.Monad.IOSync
   ( module Control.Monad.IO.Effect
   , IOSync(..)
+  , runIOSync
+  , runIOSync'
   ) where
 
 import Control.Alt (class Alt)
@@ -19,6 +21,12 @@ import Data.Newtype (class Newtype, unwrap, wrap)
 import Prelude
 
 newtype IOSync a = IOSync (Eff (infinity :: INFINITY) a)
+
+runIOSync :: IOSync ~> Eff (infinity :: INFINITY)
+runIOSync = unwrap
+
+runIOSync' :: ∀ eff. IOSync ~> Eff (infinity :: INFINITY | eff)
+runIOSync' = unsafeCoerceEff <<< unwrap
 
 derive instance newtypeIOSync :: Newtype (IOSync a) _
 

--- a/src/Control/Monad/IOSync.purs
+++ b/src/Control/Monad/IOSync.purs
@@ -12,7 +12,6 @@ import Control.Monad.Eff.Unsafe (unsafeCoerceEff)
 import Control.Monad.Error.Class (class MonadError, catchError, throwError)
 import Control.Monad.IO (INFINITY)
 import Control.Monad.Rec.Class (class MonadRec)
-import Control.MonadPlus (class MonadPlus)
 import Control.MonadZero (class MonadZero)
 import Control.Plus (class Plus)
 import Data.Monoid (class Monoid, mempty)
@@ -54,5 +53,3 @@ instance plusIOSync :: Plus IOSync where
 instance alternativeIOSync :: Alternative IOSync
 
 instance monadZeroIOSync :: MonadZero IOSync
-
-instance monadPlusIOSync :: MonadPlus IOSync

--- a/src/Control/Monad/IOSync.purs
+++ b/src/Control/Monad/IOSync.purs
@@ -1,5 +1,5 @@
 module Control.Monad.IOSync
-  ( module Control.Monad.IO
+  ( module Control.Monad.IO.Effect
   , IOSync(..)
   ) where
 
@@ -10,7 +10,7 @@ import Control.Monad.Eff.Class (class MonadEff, liftEff)
 import Control.Monad.Eff.Exception (Error, catchException, error, throwException)
 import Control.Monad.Eff.Unsafe (unsafeCoerceEff)
 import Control.Monad.Error.Class (class MonadError, catchError, throwError)
-import Control.Monad.IO (INFINITY)
+import Control.Monad.IO.Effect (INFINITY)
 import Control.Monad.Rec.Class (class MonadRec)
 import Control.MonadZero (class MonadZero)
 import Control.Plus (class Plus)

--- a/src/Control/Monad/IOSync.purs
+++ b/src/Control/Monad/IOSync.purs
@@ -1,0 +1,58 @@
+module Control.Monad.IOSync
+  ( module Control.Monad.IO
+  , IOSync(..)
+  ) where
+
+import Control.Alt (class Alt)
+import Control.Alternative (class Alternative)
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Class (class MonadEff, liftEff)
+import Control.Monad.Eff.Exception (Error, catchException, error, throwException)
+import Control.Monad.Eff.Unsafe (unsafeCoerceEff)
+import Control.Monad.Error.Class (class MonadError, catchError, throwError)
+import Control.Monad.IO (INFINITY)
+import Control.Monad.Rec.Class (class MonadRec)
+import Control.MonadPlus (class MonadPlus)
+import Control.MonadZero (class MonadZero)
+import Control.Plus (class Plus)
+import Data.Monoid (class Monoid, mempty)
+import Data.Newtype (class Newtype, unwrap, wrap)
+import Prelude
+
+newtype IOSync a = IOSync (Eff (infinity :: INFINITY) a)
+
+derive instance newtypeIOSync :: Newtype (IOSync a) _
+
+derive newtype instance functorIOSync     :: Functor     IOSync
+derive newtype instance applyIOSync       :: Apply       IOSync
+derive newtype instance applicativeIOSync :: Applicative IOSync
+derive newtype instance bindIOSync        :: Bind        IOSync
+derive newtype instance monadIOSync       :: Monad       IOSync
+
+derive newtype instance monadRecIOSync :: MonadRec IOSync
+
+instance semigroupIOSync :: (Semigroup a) => Semigroup (IOSync a) where
+  append a b = append <$> a <*> b
+
+instance monoidIOSync :: (Monoid a) => Monoid (IOSync a) where
+  mempty = pure mempty
+
+instance monadEffIOSync :: MonadEff eff IOSync where
+  liftEff = wrap <<< unsafeCoerceEff
+
+instance monadErrorIOSync :: MonadError Error IOSync where
+  catchError a k = liftEff $
+    catchException (\e -> unwrap $ k e) (unsafeCoerceEff $ unwrap a)
+  throwError = liftEff <<< throwException
+
+instance altIOSync :: Alt IOSync where
+  alt a b = a `catchError` const b
+
+instance plusIOSync :: Plus IOSync where
+  empty = throwError $ error "plusIOSync.empty"
+
+instance alternativeIOSync :: Alternative IOSync
+
+instance monadZeroIOSync :: MonadZero IOSync
+
+instance monadPlusIOSync :: MonadPlus IOSync

--- a/src/Control/Monad/IOSync/Class.purs
+++ b/src/Control/Monad/IOSync/Class.purs
@@ -1,0 +1,16 @@
+module Control.Monad.IOSync.Class where
+
+import Control.Monad.Eff.Class (liftEff)
+import Control.Monad.IO (IO)
+import Control.Monad.IOSync (IOSync)
+import Data.Newtype (unwrap, wrap)
+import Prelude
+
+class (Monad m) <= MonadIOSync m where
+  liftIOSync :: ∀ a. IOSync a -> m a
+
+instance monadIOSyncIOSync :: MonadIOSync IOSync where
+  liftIOSync = id
+
+instance monadIOSyncIO :: MonadIOSync IO where
+  liftIOSync = wrap <<< liftEff <<< unwrap

--- a/src/Control/Monad/IOSync/Class.purs
+++ b/src/Control/Monad/IOSync/Class.purs
@@ -7,7 +7,7 @@ import Data.Newtype (unwrap, wrap)
 import Prelude
 
 class (Monad m) <= MonadIOSync m where
-  liftIOSync :: ∀ a. IOSync a -> m a
+  liftIOSync :: IOSync ~> m
 
 instance monadIOSyncIOSync :: MonadIOSync IOSync where
   liftIOSync = id


### PR DESCRIPTION
Other changes:

 - Make `IO a` a newtype for `Aff (infinity :: INFINITY) a`, instead of a foreign import with `unsafeCoerce`.
 - Use newtype deriving where possible.
 - Add `runIO'` which returns an action with an open effect row.
 - No `Parallel` instance, not sure how to deal with `ParAff`.
 - Add `launchIO`.
 - Fixes #3.
