### PR TITLE
Derive Alt, Plus, and Alternative instances for ParIO

### DIFF
--- a/src/Control/Monad/IO.purs
+++ b/src/Control/Monad/IO.purs
@@ -57,6 +57,10 @@ derive newtype instance applicativeParIO :: Applicative ParIO
 derive newtype instance semigroupParIO   :: (Semigroup a) => Semigroup (ParIO a)
 derive newtype instance monoidParIO      :: (Monoid a) => Monoid (ParIO a)
 
+derive newtype instance altParIO         :: Alt ParIO
+derive newtype instance plusParIO        :: Plus ParIO
+derive newtype instance alternativeParIO :: Alternative ParIO
+
 instance monadAffIO :: MonadAff eff IO where
   liftAff = wrap <<< unsafeCoerceAff
 


### PR DESCRIPTION
These instances are available for `ParAff` and can be derived.